### PR TITLE
Fixing - Part 3

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -14,7 +14,7 @@ namespace Sonata\DoctrineORMAdminBundle\Builder;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\DoctrineORMAdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;


### PR DESCRIPTION
Fixing: Wrong search results when using custom query
Part 3: Sonata\DoctrineORM\AdminBundle\Builder\DatagridBuilder.php

Using the new Datagrid class from Sonata\DoctrineORMAdminBundle\Datagrid\